### PR TITLE
docs(readme): cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,36 +11,3 @@ Simply install dotfiles with the Dotfiles Installer. Or if you want to publish y
 
 Please have a look at the Wiki to learn how to use and configure the Dotfiles Installer:
 https://mylinuxforwork.github.io/dotfiles-installer/
-
-# Installation
-
-The ML4W Hyprland Settings App requires Flatpak & git:
-
-```
-# Install Flatpak on your distribution
-# https://flatpak.org/setup/
-
-# Install git for your distribution
-sudo pacman -S git # for Arch
-sudo dnf install git # for Fedora
-sudo zypper install git # for openSuse
-# etc.
-
-```
-> [!IMPORTANT]
-> A reboot after installing Flatpak is recommended to see application in your app launcher.
-
-Copy the following command into your terminal to install the app:
-
-```
-bash -c "$(curl -s https://raw.githubusercontent.com/mylinuxforwork/dotfiles-installer/master/setup.sh)"
-
-```
-> [!IMPORTANT]
-> The Dotfiles Installer requires a Desktop Environment (Gnome, KDE Plasma, etc.) or a Window Manager (Hyprland, Qtile, etc.). On a minimal system, please install e.g. Hyprland and a terminal first and then execute the installation command in your terminal.
-
-After the installation you can start the app from your application launcher or with:
-
-```
-flatpak run com.ml4w.dotfilesinstaller
-```


### PR DESCRIPTION
as everything is included perfectly in the wiki, we don't need to add a guide in the readme. there's already a link to the documentation, which i think is enough. wdyt?
