### PR TITLE
ci: add typo checker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,15 @@
+name: Check for typos
+
+on:
+  [push, pull_request, workflow_dispatch]
+
+jobs:
+  check-typos:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: git fetch origin ${{ github.base_ref }}
+
+      - name: Run spellcheck
+        uses: crate-ci/typos@v1.34.0

--- a/typos.toml
+++ b/typos.toml
@@ -1,20 +1,5 @@
 [default]
 locale = "en-us"
-
-# Python-specific configuration - ignore "wizzard" in Python files
-[type.py]
-extend-identifiers = { 
-    wizzard = "wizzard",
-    wizzard_stack = "wizzard_stack",
-    wizzard_next_btn = "wizzard_next_btn",
-    wizzard_back_btn = "wizzard_back_btn"
-}
-
-# UI files (GTK) - ignore "wizzard" in .ui files
-[type.ui]
-extend-identifiers = { 
-    wizzard = "wizzard",
-    wizzard_stack = "wizzard_stack", 
-    wizzard_next_btn = "wizzard_next_btn",
-    wizzard_back_btn = "wizzard_back_btn"
-}
+extend-ignore-re = [
+    "(?i)wizzard" 
+]

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,20 @@
+[default]
+locale = "en-us"
+
+# Python-specific configuration - ignore "wizzard" in Python files
+[type.py]
+extend-identifiers = { 
+    wizzard = "wizzard",
+    wizzard_stack = "wizzard_stack",
+    wizzard_next_btn = "wizzard_next_btn",
+    wizzard_back_btn = "wizzard_back_btn"
+}
+
+# UI files (GTK) - ignore "wizzard" in .ui files
+[type.ui]
+extend-identifiers = { 
+    wizzard = "wizzard",
+    wizzard_stack = "wizzard_stack", 
+    wizzard_next_btn = "wizzard_next_btn",
+    wizzard_back_btn = "wizzard_back_btn"
+}

--- a/typos.toml
+++ b/typos.toml
@@ -1,5 +1,26 @@
+# typos.toml - configuration for the typos spellchecker
+# More info: https://github.com/crate-ci/typos
+# Also: https://cocalc.com/github/bevyengine/bevy/blob/main/typos.toml
+
 [default]
 locale = "en-us"
 extend-ignore-re = [
     "(?i)wizzard" 
 ]
+
+# [default.extend-words]
+
+# [default.extend-identifiers]
+
+# [default.extend-ignore-re] # Uncomment to ignore words via regex patterns
+# "\\bNDKs\\b",               # e.g., acronym or brand names
+
+# [files]
+# ignore-hidden = false # Include hidden files
+
+# extend-exclude = [
+#  "*.pbxproj",  # Ignore Xcode project metadata
+#  "*.patch",    # Ignore patch files
+#  "*.bin",      # Ignore binary files
+#  ".git/",      # Ignore Git metadata
+# ]


### PR DESCRIPTION
see https://github.com/mylinuxforwork/dotfiles/pull/1019

check is failing for `wizzard` but i see it is used in many `.py` and `.ui` files. so i am not touching any of them. we can ignore `wizzard` directly no major impact on the repo side. other typo was already fine.
